### PR TITLE
API Key - Needed for CCPA/GDPR

### DIFF
--- a/examples/lambda-with-apigw/main.tf
+++ b/examples/lambda-with-apigw/main.tf
@@ -27,6 +27,7 @@ module lambda {
   rest_api_id        = aws_api_gateway_rest_api.api.id
   version_id         = aws_api_gateway_resource.version.id
   authorization_type = "NONE"
+  api_key_required   = true
   region             = "us-east-1"
 
   event = {

--- a/main.tf
+++ b/main.tf
@@ -25,4 +25,5 @@ module event-trigger-apigw {
   invoke_arn         = module.lambda.invoke_arn
   authorization_id   = var.authorization_id
   authorization_type = var.authorization_type
+  api_key_required = var.api_key_required
 }

--- a/main.tf
+++ b/main.tf
@@ -25,5 +25,5 @@ module event-trigger-apigw {
   invoke_arn         = module.lambda.invoke_arn
   authorization_id   = var.authorization_id
   authorization_type = var.authorization_type
-  api_key_required = var.api_key_required
+  api_key_required   = var.api_key_required
 }

--- a/modules/event-trigger/apigw/main.tf
+++ b/modules/event-trigger/apigw/main.tf
@@ -29,12 +29,12 @@ resource aws_lambda_permission allow_api_gateway {
 }
 
 resource aws_api_gateway_method request_method {
-  count         = var.enable ? 1 : 0
-  rest_api_id   = var.rest_api_id
-  resource_id   = aws_api_gateway_resource.proxy[count.index].id
-  http_method   = var.rest_method
-  authorization = var.authorization_type
-  authorizer_id = var.authorization_id
+  count            = var.enable ? 1 : 0
+  rest_api_id      = var.rest_api_id
+  resource_id      = aws_api_gateway_resource.proxy[count.index].id
+  http_method      = var.rest_method
+  authorization    = var.authorization_type
+  authorizer_id    = var.authorization_id
   api_key_required = var.api_key_required
 }
 

--- a/modules/event-trigger/apigw/main.tf
+++ b/modules/event-trigger/apigw/main.tf
@@ -35,6 +35,7 @@ resource aws_api_gateway_method request_method {
   http_method   = var.rest_method
   authorization = var.authorization_type
   authorizer_id = var.authorization_id
+  api_key_required = var.api_key_required
 }
 
 resource aws_api_gateway_integration request_integration {

--- a/modules/event-trigger/apigw/variables.tf
+++ b/modules/event-trigger/apigw/variables.tf
@@ -50,7 +50,7 @@ variable authorization_id {
 }
 
 variable api_key_required {
-  description = "Boolean indicating whther the method requires and API Key"
+  description = "Boolean indicating whether the method requires an API Key"
   type = bool
-  value = false
+  default = false
 }

--- a/modules/event-trigger/apigw/variables.tf
+++ b/modules/event-trigger/apigw/variables.tf
@@ -51,6 +51,6 @@ variable authorization_id {
 
 variable api_key_required {
   description = "Boolean indicating whether the method requires an API Key"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/modules/event-trigger/apigw/variables.tf
+++ b/modules/event-trigger/apigw/variables.tf
@@ -52,4 +52,5 @@ variable authorization_id {
 variable api_key_required {
   description = "Boolean indicating whther the method requires and API Key"
   type = bool
+  value = false
 }

--- a/modules/event-trigger/apigw/variables.tf
+++ b/modules/event-trigger/apigw/variables.tf
@@ -48,3 +48,8 @@ variable authorization_id {
   description = "The ID from the API Gateway Authorizer resource"
   type        = string
 }
+
+variable api_key_required {
+  description = "Boolean indicating whther the method requires and API Key"
+  type = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,9 @@ variable authorization_id {
   type        = string
   default     = ""
 }
+
+variable api_key_required {
+  description = "Boolean indicating whether the method requires an API Key"
+  type = bool
+  default = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,6 @@ variable authorization_id {
 
 variable api_key_required {
   description = "Boolean indicating whether the method requires an API Key"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
API Keys will be used  as authentication for the CCPA/GDPR lambdas.  This results in a change to the terraform module to allow the 'API key required' field to be marked as 'true' in AWS when creating the lambda.