### PR TITLE
[feat] honeycomb integration

### DIFF
--- a/examples/lambda-with-honeycomb-integration/main.tf
+++ b/examples/lambda-with-honeycomb-integration/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_version = ">= 0.12.21"
+}
+
+provider aws {
+  region  = "us-east-1"
+  version = ">= 2.51.0"
+}
+
+module honeycomb {
+  source             = "../../"
+  lambda_name        = "terratest"
+  handler            = "terratest"
+  lambda_description = "Lambda function to test terraform-aws-lambda module"
+  filename           = "hello_world.zip"
+  region             = "us-east-1"
+  rest_api_id        = ""
+  version_id         = ""
+  environment = {
+    variables = {
+      loglevel = "INFO"
+    }
+  }
+}
+
+module lambda {
+  depends_on = module.honeycomb
+  source             = "../../"
+  lambda_name        = "terratest2"
+  handler            = "terratest2"
+  lambda_description = "Lambda function to test terraform-aws-lambda module"
+  filename           = "hello_world.zip"
+  region             = "us-east-1"
+  rest_api_id        = ""
+  version_id         = ""
+  honeycomb_arn      = module.honeycomb.arn
+  environment = {
+    variables = {
+      loglevel = "INFO"
+    }
+  }
+}

--- a/examples/lambda-with-honeycomb-integration/main.tf
+++ b/examples/lambda-with-honeycomb-integration/main.tf
@@ -24,7 +24,6 @@ module honeycomb {
 }
 
 module lambda {
-  depends_on = module.honeycomb
   source             = "../../"
   lambda_name        = "terratest2"
   handler            = "terratest2"
@@ -33,6 +32,7 @@ module lambda {
   region             = "us-east-1"
   rest_api_id        = ""
   version_id         = ""
+  enable_honeycomb   = true
   honeycomb_arn      = module.honeycomb.arn
   environment = {
     variables = {

--- a/examples/lambda-with-honeycomb-integration/outputs.tf
+++ b/examples/lambda-with-honeycomb-integration/outputs.tf
@@ -1,0 +1,15 @@
+output arn {
+  value = module.lambda.arn
+}
+
+output function_name {
+  value = module.lambda.function_name
+}
+
+output invoke_arn {
+  value = module.lambda.invoke_arn
+}
+
+output role_name {
+  value = module.lambda.role_name
+}

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ module lambda {
   environment        = var.environment
   policy_filepath    = var.policy_filepath != "" ? var.policy_filepath : "${path.module}/templates/defaultLambdaPolicy.json"
   layers             = var.layers
+  honeycomb_arn      = var.honeycomb_arn
 }
 
 module event-trigger-apigw {

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ module lambda {
   environment        = var.environment
   policy_filepath    = var.policy_filepath != "" ? var.policy_filepath : "${path.module}/templates/defaultLambdaPolicy.json"
   layers             = var.layers
+  enable_honeycomb   = var.enable_honeycomb
   honeycomb_arn      = var.honeycomb_arn
 }
 

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -60,6 +60,14 @@ resource aws_cloudwatch_log_group log_group {
   name  = "/aws/lambda/${var.lambda_name}_lambda"
 }
 
+resource aws_lambda_permission allow_cloudwatch {
+  count         = var.enable_honeycomb != false ? 1 : 0
+  statement_id  = "allow_cloudwatch"
+  action        = "lambda:InvokeFunction"
+  function_name = var.honeycomb_arn
+  principal     = "logs.${var.region}.amazonaws.com"
+  source_arn    = aws_cloudwatch_log_group.log_group[0].arn
+}
 resource aws_cloudwatch_log_subscription_filter cloudwatch_subscription_filter {
   count = var.honeycomb_arn != "" ? 1 : 0
   depends_on = [

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -54,3 +54,19 @@ resource aws_iam_role_policy lambda_policy {
   policy = templatefile(var.policy_filepath, {})
 
 }
+
+resource aws_cloudwatch_log_group log_group {
+  count = var.honeycomb_arn != "" ? 1 : 0
+  name  = "/aws/lambda/${var.lambda_name}_lambda"
+}
+
+resource aws_cloudwatch_log_subscription_filter cloudwatch_subscription_filter {
+  count = var.honeycomb_arn != "" ? 1 : 0
+  depends_on = [
+    aws_cloudwatch_log_group.log_group[0]
+  ]
+  name            = "${var.lambda_name}-lambda-log-group-subscription"
+  log_group_name  = "/aws/lambda/${var.lambda_name}_lambda"
+  filter_pattern  = ""
+  destination_arn = var.honeycomb_arn
+}

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -56,7 +56,7 @@ resource aws_iam_role_policy lambda_policy {
 }
 
 resource aws_cloudwatch_log_group log_group {
-  count = var.honeycomb_arn != "" ? 1 : 0
+  count = var.enable_honeycomb != false ? 1 : 0
   name  = "/aws/lambda/${var.lambda_name}_lambda"
 }
 
@@ -68,10 +68,12 @@ resource aws_lambda_permission allow_cloudwatch {
   principal     = "logs.${var.region}.amazonaws.com"
   source_arn    = aws_cloudwatch_log_group.log_group[0].arn
 }
+
 resource aws_cloudwatch_log_subscription_filter cloudwatch_subscription_filter {
-  count = var.honeycomb_arn != "" ? 1 : 0
+  count      = var.enable_honeycomb != false ? 1 : 0
   depends_on = [
-    aws_cloudwatch_log_group.log_group[0]
+    aws_cloudwatch_log_group.log_group[0],
+    aws_lambda_permission.allow_cloudwatch
   ]
   name            = "${var.lambda_name}-lambda-log-group-subscription"
   log_group_name  = "/aws/lambda/${var.lambda_name}_lambda"

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -58,3 +58,9 @@ variable "layers" {
   type        = list
   default     = []
 }
+
+variable honeycomb_arn {
+  type        = string
+  description = "The ARN of the Lambda that pipes logs into Honeycomb"
+  default     = ""
+}

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -59,6 +59,12 @@ variable "layers" {
   default     = []
 }
 
+variable "enable_honeycomb" {
+  type    = bool
+  description = "Enable logging to Honeycomb for this function"
+  default = false
+}
+
 variable honeycomb_arn {
   type        = string
   description = "The ARN of the Lambda that pipes logs into Honeycomb"

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,9 @@ variable "layers" {
   type        = list
   default     = []
 }
+
+variable honeycomb_arn {
+  type        = string
+  description = "The ARN of the Lambda that pipes logs into Honeycomb"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,12 @@ variable "layers" {
   default     = []
 }
 
+variable "enable_honeycomb" {
+  type    = bool
+  description = "Enable logging to Honeycomb for this function"
+  default = false
+}
+
 variable honeycomb_arn {
   type        = string
   description = "The ARN of the Lambda that pipes logs into Honeycomb"


### PR DESCRIPTION
Putting this here to chew on, and it probably needs some iteration. The example seemed to run fine as long as the Honeycomb function already exists, but failed to do so otherwise. `depends_on` isn't implemented for modules right now, and I'm not sure if it's worth building in a workaround

Also totally fine if we don't want this integration in the lambda module