### PR TITLE
Feat/function versioning

### DIFF
--- a/examples/lambda-without-event/main.tf
+++ b/examples/lambda-without-event/main.tf
@@ -17,6 +17,7 @@ module lambda {
   region                         = "us-east-1"
   rest_api_id                    = ""
   version_id                     = ""
+  publish                        = true
   reserved_concurrent_executions = 2
   environment = {
     variables = {

--- a/examples/lambda-without-event/outputs.tf
+++ b/examples/lambda-without-event/outputs.tf
@@ -13,3 +13,7 @@ output invoke_arn {
 output role_name {
   value = module.lambda.role_name
 }
+
+output function_version {
+  value = module.lambda.function_version
+}

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ module lambda {
   environment                    = var.environment
   policy_filepath                = var.policy_filepath != "" ? var.policy_filepath : "${path.module}/templates/defaultLambdaPolicy.json"
   layers                         = var.layers
+  publish                        = var.publish
   reserved_concurrent_executions = var.reserved_concurrent_executions
 }
 

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -18,6 +18,7 @@ resource aws_lambda_function lambda {
   memory_size                    = var.memory_size
   timeout                        = var.timeout
   layers                         = var.layers
+  publish                        = var.publish
   reserved_concurrent_executions = var.reserved_concurrent_executions
   dynamic "environment" {
     for_each = length(var.environment) < 1 ? [] : [var.environment]

--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -17,3 +17,8 @@ output role_name {
   description = "The name of the IAM attached to the Lambda Function."
   value       = aws_iam_role.lambda_role.name
 }
+
+output function_version {
+  description = "The latest published version of the Lambda Function."
+  value       = aws_lambda_function.lambda.version
+}

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -64,3 +64,9 @@ variable reserved_concurrent_executions {
   type        = number
   default     = -1
 }
+
+variable publish {
+  description = "Whether to publish creation/change as new Lambda Function Version"
+  type        = bool
+  default     = false
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output role_name {
   description = "The name of the IAM role attached to the Lambda Function."
   value       = module.lambda.role_name
 }
+
+output function_version {
+  description = "The latest published version of the Lambda Function."
+  value       = module.lambda.function_version
+}

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,9 @@ variable reserved_concurrent_executions {
   type        = number
   default     = -1
 }
+
+variable publish {
+  description = "Whether to publish creation/change as new Lambda Function Version"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Apparently to use provisioned concurrency you have to point the reserved executions to a specific version/alias of a function. This means we have to enable publishing new versions of the function as well as exporting the function version.