### PR TITLE
add source_code_hash as a variable that needs to be passed in rather …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ module lambda {
   layers                         = var.layers
   publish                        = var.publish
   reserved_concurrent_executions = var.reserved_concurrent_executions
+  source_code_hash               = var.source_code_hash
 }
 
 module event-trigger-apigw {

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -15,7 +15,7 @@ resource aws_lambda_function lambda {
   role              = aws_iam_role.lambda_role.arn
   handler           = var.handler
 
-  source_code_hash = var.s3_bucket == "" ? filebase64sha256(var.filename) : null
+  source_code_hash = var.source_code_hash != "" ? var.source_code_hash : null
 
   runtime                        = var.runtime
   memory_size                    = var.memory_size

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -89,3 +89,9 @@ variable publish {
   type        = bool
   default     = false
 }
+
+variable source_code_hash {
+  description = "Source code hash to use for the Lambda function."
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,3 +127,9 @@ variable publish {
   type        = bool
   default     = false
 }
+
+variable source_code_hash {
+  description = "Source code hash to use for the Lambda function."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
With support for either a local file or an S3 file as the deployment package, the user needs to pass in the source_code_hash accordingly if they want to use that feature. This update sets up the variables for this.