### PR TITLE
Adding EFS configuration variables.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,10 @@ module "lambda" {
   source_code_hash               = var.source_code_hash
   memory_size                    = var.memory_size
   timeout                        = var.timeout
+  subnet_ids                     = var.subnet_ids
+  security_group_ids             = var.security_group_ids
+  file_system_config_arn         = var.file_system_config_arn
+  local_mount_path               = var.local_mount_path
 }
 
 module "event-trigger-apigw" {

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -30,6 +30,25 @@ resource aws_lambda_function lambda {
       variables = environment.value.variables
     }
   }
+
+  // Only create vpc_config block if var.security_group_ids has a value
+  dynamic "vpc_config" {
+    for_each = var.security_group_ids[0] == "" ? [] : [1]
+    content {
+      security_group_ids = var.security_group_ids
+      subnet_ids         = var.subnet_ids
+    }
+  }
+
+  // Only create file_system_config block if var.file_system_config has a value
+  dynamic "file_system_config" {
+    for_each = var.file_system_config_arn == "" ? [] : [1]
+    content {
+      arn              = var.file_system_config_arn
+      local_mount_path = var.local_mount_path
+    }
+  }
+
 }
 
 resource aws_iam_role lambda_role {

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -95,3 +95,27 @@ variable source_code_hash {
   type        = string
   default     = ""
 }
+
+variable security_group_ids {
+  description = "Security group ids"
+  type        = list
+  default     = []
+}
+
+variable subnet_ids {
+  description = "Subnet ids"
+  type        = list
+  default     = []
+}
+
+variable file_system_config_arn {
+  description = "EFS file system access point ARN"
+  type        = string
+  default     = ""
+}
+
+variable local_mount_path {
+  description = "Local mount path inside the lambda function. Must start with '/mnt/'"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -133,3 +133,27 @@ variable source_code_hash {
   type        = string
   default     = ""
 }
+
+variable security_group_ids {
+  description = "Security group ids"
+  type        = list
+  default     = []
+}
+
+variable subnet_ids {
+  description = "Subnet ids"
+  type        = list
+  default     = []
+}
+
+variable file_system_config_arn {
+  description = "EFS file system access point ARN"
+  type        = string
+  default     = ""
+}
+
+variable local_mount_path {
+  description = "Local mount path inside the lambda function. Must start with '/mnt/'"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
In order to support Lambda EFS configuration the following variables were added:

-  subnet_ids 
- security_group_ids
- file_system_config_arn
- local_mount_path

Because these values are assigned inside of blocks, we need to dynamically create them only if a variable exists using the example below:

```terraform
// Only create vpc_config block if var.security_group_ids has a value
  dynamic "vpc_config" {
    for_each = var.security_group_ids[0] == "" ? [] : [1]
    content {
      security_group_ids = var.security_group_ids
      subnet_ids         = var.subnet_ids
    }
  }
```